### PR TITLE
Issue #17.3: override default header color in callout block

### DIFF
--- a/blocks/callout/callout.css
+++ b/blocks/callout/callout.css
@@ -29,6 +29,7 @@
       padding: 80px;
   
       h3 {
+        color: var(--theme-clr-text);
         font-family: var(--heading-font-family);
         font-size: 1.5rem;
         line-height: 2.5rem;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #17 

Test URLs:
- Before: https://main--ingredion--aemsites.aem.live/drafts/gfiscaletti/callout
- After: https://issue-17-fix--ingredion--aemsites.aem.live/drafts/gfiscaletti/callout
