### PR TITLE
issue-79.2: fix link styling for the events template

### DIFF
--- a/templates/events/events.css
+++ b/templates/events/events.css
@@ -93,9 +93,22 @@
     object-fit: cover;
 }
 
-.event-detail-content a {
+.event-detail-content p a {
     color: var(--green);
     text-decoration: underline;
+    background: transparent;
+    font-size: 1.375rem;
+    line-height: 2rem;
+    font-family: OpenSans-Regular, Helvetica, sans-serif;
+    letter-spacing: .015625rem;
+    padding: 0;
+    text-transform: none;
+}
+
+.event-detail-content p a:hover {
+    text-decoration: underline;
+    color: var(--dark-green);
+    background: transparent;
 }
 
 .register-event {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #79 

Test URLs:
- Before: https://main--ingredion--aemsites.aem.live/na/en-us/news-events/events/in-cosmetics-global-2023
- After: https://issue-79-fix--ingredion--aemsites.aem.page/na/en-us/news-events/events/in-cosmetics-global-2023
