### PR TITLE
Fix default variant and general style of callout block

### DIFF
--- a/blocks/callout/callout.css
+++ b/blocks/callout/callout.css
@@ -177,8 +177,8 @@
         box-sizing: border-box;
         position: absolute;
         color: var(--green);
-        border-top: 10px solid default;
-        border-bottom: 10px solid default;
+        border-top: 10px solid transparent;
+        border-bottom: 10px solid transparent;
         border-left: 14px solid var(--green);
         top: 50%;
         left: calc(50% + 3px);

--- a/blocks/callout/callout.css
+++ b/blocks/callout/callout.css
@@ -283,6 +283,7 @@
         text-align: left;
         margin: 0;
         margin-left: auto;
+        padding: 0;
 
         h3 {
           margin: 0;

--- a/blocks/callout/callout.css
+++ b/blocks/callout/callout.css
@@ -62,7 +62,7 @@
   }
 }
 
-.transparent {
+.default {
   margin: 0 15px;
 
   > div {
@@ -171,8 +171,8 @@
         box-sizing: border-box;
         position: absolute;
         color: var(--green);
-        border-top: 10px solid transparent;
-        border-bottom: 10px solid transparent;
+        border-top: 10px solid default;
+        border-bottom: 10px solid default;
         border-left: 14px solid var(--green);
         top: 50%;
         left: calc(50% + 3px);
@@ -321,7 +321,7 @@
     }
   }
 
-  .transparent {
+  .default {
     margin: 0;
     
     > div {

--- a/blocks/callout/callout.css
+++ b/blocks/callout/callout.css
@@ -27,13 +27,26 @@
     .callout-content {
       color: var(--theme-clr-text);
       padding: 80px;
-  
-      h3 {
+
+      h1, h2, h3 {
         color: var(--theme-clr-text);
         font-family: var(--heading-font-family);
+        letter-spacing: -.0313rem;
+      }
+
+      h1 {
+        font-size: 2.5rem;
+        line-height: 3.5rem;
+      }
+
+      h2 {
+        font-size: 2rem;
+        line-height: 3rem;
+      }
+  
+      h3 {
         font-size: 1.5rem;
         line-height: 2.5rem;
-        letter-spacing: -.0313rem;
       }
   
       p, ul, li {
@@ -70,13 +83,6 @@
       order: -1;
       padding: 0;
       padding-bottom: 40px;
-      
-      h1 {
-        font-family: var(--heading-font-family);
-        font-size: 2.5rem;
-        line-height: 2.5rem;
-        letter-spacing: -.0313rem;
-      }
     }
 
     .button-container {
@@ -252,7 +258,7 @@
         padding: 100px;
 
         h3 {
-          font-size: 32px;
+          font-size: 2rem;
           max-width: 381px;
           margin-top: 16px;
         }
@@ -285,7 +291,7 @@
         margin-left: auto;
         padding: 0;
 
-        h3 {
+        h1, h2, h3 {
           margin: 0;
           max-width: 592px;
         }

--- a/blocks/callout/callout.js
+++ b/blocks/callout/callout.js
@@ -1,5 +1,16 @@
 import { createOptimizedPicture } from '../../scripts/aem.js';
 
+const themeColors = [
+  'blue',
+  'teal',
+  'green',
+  'orange',
+  'red',
+  'lilac',
+  'purple',
+  'dark-purple',
+];
+
 function embedVimeo(url, autoplay, background) {
   const [, video] = url.pathname.split('/');
   let suffix = '';
@@ -109,8 +120,13 @@ export default function decorate(block) {
 
   textWrapper.classList.add('callout-content');
 
-  if (link && !block.classList.contains('transparent')) {
-    link.classList.add('transparent');
+  const classListArray = Array.from(block.classList);
+
+  const hasThemeColor = themeColors.some((color) => classListArray.includes(color));
+  if (!hasThemeColor) {
+    block.classList.add('default');
+  } else if (link) {
+    link.classList.add('transparent'); // apply transparent button style
   }
 
   if (pic) {

--- a/blocks/callout/callout.js
+++ b/blocks/callout/callout.js
@@ -109,7 +109,7 @@ export default function decorate(block) {
 
   textWrapper.classList.add('callout-content');
 
-  if (!block.classList.contains('transparent')) {
+  if (link && !block.classList.contains('transparent')) {
     link.classList.add('transparent');
   }
 

--- a/blocks/callout/callout.js
+++ b/blocks/callout/callout.js
@@ -107,17 +107,13 @@ const loadVideoEmbed = (block, link, autoplay, background) => {
 export default function decorate(block) {
   const pic = block.querySelector('picture');
   const h3 = block.querySelector('h3');
+  const h2 = block.querySelector('h2');
   const h1 = block.querySelector('h1');
   const link = block.querySelector('a');
 
-  let textWrapper;
+  const header = h1 ?? h2 ?? h3;
 
-  if (h1) {
-    textWrapper = h1.closest('div');
-  } else if (h3) {
-    textWrapper = h3.closest('div');
-  }
-
+  const textWrapper = header.closest('div');
   textWrapper.classList.add('callout-content');
 
   const classListArray = Array.from(block.classList);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #92 

The `transparent` block is not a variant anymore, but the default when no theme color (or invalid theme color) is passed.
PR also includes adjustments to style to support more headings. 

Test URLs:
- Before: https://main--ingredion--aemsites.aem.live/na/en-us/categories/food/bakery
- After: https://issue-92--ingredion--aemsites.aem.live/na/en-us/categories/food/bakery
