### PR TITLE
Issue 171 - Quote Block: Support added for empty subheading and text fields

### DIFF
--- a/blocks/quote/quote.js
+++ b/blocks/quote/quote.js
@@ -18,9 +18,9 @@ export default async function decorate(block) {
   const secondSubheading = document.querySelector('.quoteblock-wrapper .label-text.label-text-center');
   const paragraphs = document.querySelectorAll('.quoteblock-wrapper ~ p');
 
-  if (paragraphs.length >= 3) {
+  if (paragraphs.length >= 1) {
     mainHeading.appendChild(paragraphs[0]);
-    firstSubheading.appendChild(paragraphs[1]);
+    firstSubheading.appendChild(paragraphs[1]); 
     secondSubheading.appendChild(paragraphs[2]);
   }
 }

--- a/blocks/quote/quote.js
+++ b/blocks/quote/quote.js
@@ -20,7 +20,7 @@ export default async function decorate(block) {
 
   if (paragraphs.length >= 1) {
     mainHeading.appendChild(paragraphs[0]);
-    firstSubheading.appendChild(paragraphs[1]); 
+    firstSubheading.appendChild(paragraphs[1]);
     secondSubheading.appendChild(paragraphs[2]);
   }
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #171 

Test URLs:
- Before: https://main--ingredion--aemsites.aem.live/na/en-us/company/meet-ingredion#our-purpose
- After: https://issue-171--ingredion--aemsites.aem.live/na/en-us/company/meet-ingredion#our-purpose