### PR TITLE
Issue 417: fix href color in green callout blocks

### DIFF
--- a/blocks/callout/callout.js
+++ b/blocks/callout/callout.js
@@ -140,7 +140,9 @@ export default function decorate(block) {
   }
 
   if (themeColor === 'green') {
-    block.querySelectorAll('a').forEach(a => a.style.color = 'var(--white)');
+    block.querySelectorAll('a').forEach((a) => {
+      a.style.color = 'var(--white)';
+    });
   }
 
   if (pic) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #417 

Test URLs:
- Before: https://main--ingredion--aemsites.aem.live/na/en-us/ingredients/ingredient-types/sweeteners
- After: https://issue-417--ingredion--aemsites.aem.live/na/en-us/ingredients/ingredient-types/sweeteners
