### PR TITLE
Issue 403: remove padding-right from slim cards cta

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -236,7 +236,6 @@
   line-height: 1.5rem;
   letter-spacing: .0313rem;
   position: relative;
-  padding-right: 1.25rem;
   font-family: MiloPro-Bold, Helvetica, sans-serif;
   color: #61a037;
   min-width: auto;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #403 

Test URLs:
- Before: https://main--ingredion--aemsites.aem.live/na/en-us/ingredients/ingredient-product-families/novation-functional-native-starches
- After: https://issue-403--ingredion--aemsites.aem.page/na/en-us/ingredients/ingredient-product-families/novation-functional-native-starches
