### PR TITLE
Fix: Constrain Gallery and Single-Image Card Layouts (#ISSUE_ID)

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -619,3 +619,24 @@ main > .section > .default-content-wrapper {
   }
 }
 
+.cards > ul:only-child,
+.cards > ul.single-image {
+  display: flex !important;
+  justify-content: center;
+}
+
+.cards > ul.single-image > li {
+  max-width: 400px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.cards > ul.single-image > li img {
+  aspect-ratio: 1 / 1;
+  max-width: 100%;
+  max-height: 300px;
+  object-fit: contain;
+  display: block;
+  margin: 0 auto;
+}
+

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -241,6 +241,12 @@ export default async function decorate(block) {
   ul.querySelectorAll('picture > img').forEach((img) => img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])));
   block.textContent = '';
   block.append(ul);
+
+  // Add single-image class if only one card
+  if (ul.children.length === 1) {
+    ul.classList.add('single-image');
+  }
+
   if (block.classList.contains('slim')) {
     const dotsNav = document.createElement('div');
     dotsNav.className = 'dots-nav';

--- a/templates/ingredient/ingredient.css
+++ b/templates/ingredient/ingredient.css
@@ -348,9 +348,12 @@ html { scroll-behavior: smooth }
         }
 
         img {
+          max-height: 350px;
           width: 100%;
-          height: 100%;
-          object-fit: cover;
+          height: auto;
+          object-fit: contain;
+          display: block;
+          margin: 0 auto;
         }
 
         .vimeo-player {


### PR DESCRIPTION
What this PR does

Constrains gallery images (e.g., "Pulse protein - Blueberry yogurt") to a max height and uses object-fit: contain to prevent oversized or cropped images on the metabolic health page and similar layouts.
Updates card layouts so that when only one card/image is present, it is centered and visually balanced, both on desktop and mobile.
Adds logic to automatically apply a .single-image class to the card container when only one card is present, triggering the new styles.

How it changes the existing code

**[ingredient.css](https://expert-guide-q7vp54qx45g43449w.github.dev/):** Adds max-height: 350px; object-fit: contain; to gallery images.
**[cards.css](https://expert-guide-q7vp54qx45g43449w.github.dev/):** Adds styles for .single-image cards to center and size the image appropriately.
**[cards.js](https://expert-guide-q7vp54qx45g43449w.github.dev/):** Adds logic to apply the .single-image class to the <ul> if there is only one card.

Breaking change

None expected. The changes are scoped to gallery and card layouts and should not affect other components.

**Test URLs:
- Before: https://main--ingredion--aemsites.aem.live/
**- After: https://<branch>--ingredion--aemsites.aem.live/**
