### PR TITLE
Align heading text to the left in CTA icons section

### DIFF
--- a/blocks/cta-icons/cta-icons.css
+++ b/blocks/cta-icons/cta-icons.css
@@ -9,17 +9,7 @@
   max-width: 50.1875rem;
 }
 
-.default-content-wrapper h2 {
-  text-align: center;
-  font-family: MiloPro-Bold, Helvetica, sans-serif;
-  font-size: 2rem;
-  margin: 0 0 1rem;
-  color: var(--text-color);
-  line-height: 3rem;
-  letter-spacing: -0.0313rem;
-}
-
-h2#crea-el-futuro-con-personas-a-las-que-les-importa {
+.cta-icons > h2{
   text-align: left;
 }
 

--- a/blocks/cta-icons/cta-icons.css
+++ b/blocks/cta-icons/cta-icons.css
@@ -19,6 +19,10 @@
   letter-spacing: -0.0313rem;
 }
 
+h2#crea-el-futuro-con-personas-a-las-que-les-importa {
+  text-align: left;
+}
+
 .cta-icons.section-content-columns-4 > a, .cta-icons.section-content-columns-6 > a {
   margin: 0 0.75rem 1.5rem;
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #447

Test URLs:
- Before: https://main--ingredion--aemsites.aem.page/na/es-mx/compania/carrera
- After: https://cta-icons-h2--ingredion--aemsites.aem.page/na/es-mx/compania/carrera
