### PR TITLE
Set max-width for default content wrapper in cards block

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -609,6 +609,7 @@ main > .section > .default-content-wrapper {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(40%, 1fr));
     gap: 40px 20px;
+    max-width: 63.25rem;
   }
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #494

Test URLs:
- Before: https://main--ingredion--aemsites.aem.page/na/en-us/solving-a-challenge/innovation-with-idea-labs/snacking-innovation-community/consumer-challenges
- After: https://cards-two-column-width--ingredion--aemsites.aem.page/na/en-us/solving-a-challenge/innovation-with-idea-labs/snacking-innovation-community/consumer-challenges
