### PR TITLE
fix: Rename "move-as-header" to "move-to-http-header"

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,7 +5,7 @@
   <meta
     http-equiv="Content-Security-Policy"
     content="script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';"
-    move-as-header="true"
+    move-to-http-header="true"
   >
   <title>Error</title>
   <script nonce="aem" type="text/javascript">

--- a/head.html
+++ b/head.html
@@ -1,7 +1,7 @@
 <meta
   http-equiv="Content-Security-Policy"
   content="script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';"
-  move-as-header="true"
+  move-to-http-header="true"
 >
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script nonce="aem" src="/scripts/aem.js" type="module"></script>


### PR DESCRIPTION
With the rollout to the this content security policy to the aem boilerplate, the attribute name was also changed to make it more clear. 

Test URLs:
- Before: https://main--ingredion--aemsites.aem.live/?martech=off
- After: https://migrate-naming--ingredion--aemsites.aem.live/?martech=off
