### PR TITLE
Revert "add product-apis for en-sg" because this change is causing the APAC pages API to return a blank response

### DIFF
--- a/scripts/product-api.js
+++ b/scripts/product-api.js
@@ -31,57 +31,46 @@ export const API_PATH_OVERRIDES = {
   POPULATE_INGREDIENT_CATEGORY_SUBCATEGORY: {
     'na-es-mx': '/bin/ingredion-com/headeringredient/header.es-mx.search.json',
     'na-kerr': '/bin/ingredion-com/headeringredient/header.kerr.search.json',
-    'apac-en-sg': '/bin/ingredion-com/headeringredient/header.en-sg.search.json',
   },
   SEARCH_INGREDIENT_BY_CATEGORY_SUBCATEGORY: {
     'na-es-mx': '/bin/ingredion-com/ingredient-finder.es-mx.search.json',
     'na-kerr': '/bin/ingredion-com/ingredient-finder.kerr.search.json',
-    'apac-en-sg': '/bin/ingredion-com/ingredient-finder.en-sg.search.json',
   },
   INGREDIENT_SEARCH_TYPEAHEAD: {
     'na-es-mx': '/bin/ingredion-com/typeaheadingredient.es-mx.ingredient-search-typeahead.json',
     'na-kerr': '/bin/ingredion-com/typeaheadingredient.kerr.ingredient-search-typeahead.json',
-    'apac-en-sg': '/bin/ingredion-com/typeaheadingredient.en-sg.ingredient-search-typeahead.json',
   },
   PRODUCT_DETAILS: {
     'na-es-mx': '/bin/ingredion-com/searchResults.es-mx.ingredients.json',
     'na-kerr': '/bin/ingredion-com/searchResults.kerr.ingredients.json',
-    'apac-en-sg': '/bin/ingredion-com/searchResults.en-sg.ingredients.json',
   },
   ALL_DOCUMENTS: {
     'na-es-mx': '/bin/ingredion-com/documents.es-mx.view.json',
     'na-kerr': '/bin/ingredion-com/documents.kerr.view.json',
-    'apac-en-sg': '/bin/ingredion-com/documents.en-sg.view.json',
   },
   DOWNLOAD_DOCUMENTS: {
     'na-es-mx': '/bin/ingredion-com/documents-download.es-mx.download.zip',
     'na-kerr': '/bin/ingredion-com/documents-download.kerr.download.zip',
-    'apac-en-sg': '/bin/ingredion-com/documents-download.en-sg.download.zip',
   },
   DOWNLOAD_ALL_DOCUMENTS: {
     'na-es-mx': '/bin/ingredion-com/documents-download.es-mx.download.zip',
     'na-kerr': '/bin/ingredion-com/documents-download.kerr.download.zip',
-    'apac-en-sg': '/bin/ingredion-com/documents-download.en-sg.download.zip',
   },
   DOWNLOAD_ALL_DOCUMENTS_FROM_SEARCH: {
     'na-es-mx': '/bin/ingredion-com/documents-download.es-mx.download.zip',
     'na-kerr': '/bin/ingredion-com/documents-download.kerr.download.zip',
-    'apac-en-sg': '/bin/ingredion-com/documents-download.en-sg.download.zip',
   },
   SEARCH_INGREDIENTS: {
     'na-es-mx': '/bin/ingredion-com/searchResults.es-mx.ingredients.json',
     'na-kerr': '/bin/ingredion-com/searchResults.kerr.ingredients.json',
-    'apac-en-sg': '/bin/ingredion-com/searchResults.en-sg.ingredients.json',
   },
   SEARCH_DOCUMENTS: {
     'na-es-mx': '/bin/ingredion-com/tech-documents.es-mx.techDocs.json',
     'na-kerr': '/bin/ingredion-com/tech-documents.kerr.techDocs.json',
-    'apac-en-sg': '/bin/ingredion-com/tech-documents.en-sg.techDocs.json',
   },
   SEARCH_INGREDIENTS_BY_NAME: {
     'na-es-mx': '/bin/ingredion-com/ingredient-finder.es-mx.search.json',
     'na-kerr': '/bin/ingredion-com/ingredient-finder.kerr.search.json',
-    'apac-en-sg': '/bin/ingredion-com/ingredient-finder.en-sg.search.json',
   },
 };
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix : Reverts aemsites/ingredion#658 

Test URLs:
- Before: https://main--ingredion--aemsites.aem.page/apac/en-sg/solving-a-challenge/innovation-with-idea-labs/snacking/snacking-knowledge/rice-crackers?martech=off
- After: https://revert-658-issue-142--ingredion--aemsites.aem.page/apac/en-sg/solving-a-challenge/innovation-with-idea-labs/snacking/snacking-knowledge/rice-crackers?martech=off