### PR TITLE
Adding Tabbing in search ingredion page

### DIFF
--- a/blocks/article-list/article-renderer.js
+++ b/blocks/article-list/article-renderer.js
@@ -18,7 +18,7 @@ function createSelectDropdown({
   cssClass = [],
 }) {
   const $dropdown = div({ class: ['select-dropdown', cssClass] },
-    div({ class: 'selected' }, `${labelPrefix}${selectedValue || defaultText}${labelSuffix}`),
+    div({ class: 'selected', tabindex: '0' }, `${labelPrefix}${selectedValue || defaultText}${labelSuffix}`),
     ul({ class: 'options' }),
   );
 

--- a/blocks/ingredient-finder/ingredient-finder.js
+++ b/blocks/ingredient-finder/ingredient-finder.js
@@ -124,18 +124,6 @@ function createDropdownOption(item) {
     }
   });
 
-  // Add focus/blur visual indicators
-  optionDiv.addEventListener('focus', () => {
-    optionDiv.style.backgroundColor = '#f0f0f0';
-    optionDiv.style.outline = '2px solid #01090e';
-    optionDiv.style.outlineOffset = '-2px';
-  });
-  optionDiv.addEventListener('blur', () => {
-    optionDiv.style.backgroundColor = '';
-    optionDiv.style.outline = '';
-    optionDiv.style.outlineOffset = '';
-  });
-
   return optionDiv;
 }
 
@@ -297,32 +285,6 @@ export default async function decorate(block) {
       { class: 'dropdown-options hidden' },
       ...data.applications.map(createDropdownOption),
     );
-
-    // Add keyboard navigation for dropdown options
-    options.addEventListener('keydown', (e) => {
-      if (options.classList.contains('hidden')) return;
-
-      const currentOptions = Array.from(options.querySelectorAll('.dropdown-option'));
-      const currentIndex = currentOptions.findIndex(opt => opt === document.activeElement);
-
-      switch (e.key) {
-        case 'ArrowDown':
-          e.preventDefault();
-          const nextIndex = Math.min(currentIndex + 1, currentOptions.length - 1);
-          currentOptions[nextIndex].focus();
-          break;
-        case 'ArrowUp':
-          e.preventDefault();
-          const prevIndex = Math.max(currentIndex - 1, 0);
-          currentOptions[prevIndex].focus();
-          break;
-        case 'Escape':
-          e.preventDefault();
-          options.classList.add('hidden');
-          $application.focus();
-          break;
-      }
-    });
     const $application = div(
       { class: 'application select-dropdown', tabindex: '0'  },
       initialTab,
@@ -335,14 +297,8 @@ export default async function decorate(block) {
       if (e.key === 'Enter') {
         e.preventDefault();
         e.stopPropagation();
-        const wasHidden = options.classList.contains('hidden');
         options.classList.toggle('hidden');
         dropdownOptions1.classList.add('hidden');
-        if (wasHidden && !options.classList.contains('hidden')) {
-          // Focus first option when opening
-          const firstOption = options.querySelector('.dropdown-option');
-          if (firstOption) firstOption.focus();
-        }
       }
     });
 
@@ -364,32 +320,6 @@ export default async function decorate(block) {
     });
     const selected1 = div({ class: 'selected disabled' }, subApplicationText);
     const dropdownOptions1 = div({ class: 'dropdown-options hidden' });
-
-    // Add keyboard navigation for sub-application dropdown options
-    dropdownOptions1.addEventListener('keydown', (e) => {
-      if (dropdownOptions1.classList.contains('hidden')) return;
-
-      const currentOptions = Array.from(dropdownOptions1.querySelectorAll('.dropdown-option'));
-      const currentIndex = currentOptions.findIndex(opt => opt === document.activeElement);
-
-      switch (e.key) {
-        case 'ArrowDown':
-          e.preventDefault();
-          const nextIndex = Math.min(currentIndex + 1, currentOptions.length - 1);
-          currentOptions[nextIndex].focus();
-          break;
-        case 'ArrowUp':
-          e.preventDefault();
-          const prevIndex = Math.max(currentIndex - 1, 0);
-          currentOptions[prevIndex].focus();
-          break;
-        case 'Escape':
-          e.preventDefault();
-          dropdownOptions1.classList.add('hidden');
-          $subApplication.focus();
-          break;
-      }
-    });
     const $subApplication = div(
       { class: 'sub-application select-dropdown disabled', tabindex: '0' },
       initialTab1,
@@ -402,13 +332,7 @@ export default async function decorate(block) {
       if (e.key === 'Enter' && !$subApplication.classList.contains('disabled')) {
         e.preventDefault();
         e.stopPropagation();
-        const wasHidden = dropdownOptions1.classList.contains('hidden');
         dropdownOptions1.classList.toggle('hidden');
-        if (wasHidden && !dropdownOptions1.classList.contains('hidden')) {
-          // Focus first option when opening
-          const firstOption = dropdownOptions1.querySelector('.dropdown-option');
-          if (firstOption) firstOption.focus();
-        }
       }
     });
 
@@ -482,11 +406,6 @@ export default async function decorate(block) {
       const wasHidden = options.classList.contains('hidden');
       options.classList.toggle('hidden');
       dropdownOptions1.classList.add('hidden');
-      if (wasHidden && !options.classList.contains('hidden')) {
-        // Focus first option when opening
-        const firstOption = options.querySelector('.dropdown-option');
-        if (firstOption) firstOption.focus();
-      }
     });
 
     options.addEventListener('click', (e) => {
@@ -526,13 +445,7 @@ export default async function decorate(block) {
         return;
       }
       e.stopPropagation();
-      const wasHidden = dropdownOptions1.classList.contains('hidden');
       dropdownOptions1.classList.toggle('hidden');
-      if (wasHidden && !dropdownOptions1.classList.contains('hidden')) {
-        // Focus first option when opening
-        const firstOption = dropdownOptions1.querySelector('.dropdown-option');
-        if (firstOption) firstOption.focus();
-      }
     });
 
     dropdownOptions1.addEventListener('click', (e) => {

--- a/blocks/ingredient-finder/ingredient-finder.js
+++ b/blocks/ingredient-finder/ingredient-finder.js
@@ -40,9 +40,9 @@ async function createIngredientPanel(ingredientResults) {
     const description = div({ class: 'description' });
     const tempDiv = document.createElement('div');
     tempDiv.innerHTML = (article.description).replace(/&nbsp;/g, ' ');
-    tempDiv.querySelectorAll('a').forEach(link => link.setAttribute('tabindex', '-1'));
+    tempDiv.querySelectorAll('a').forEach((link) => link.setAttribute('tabindex', '-1'));
     description.innerHTML = tempDiv.innerHTML;
-    
+
     const viewAllDocsLink = a({ class: 'view-all', tabindex: '0' }, translate('view-all-documents'));
     viewAllDocsLink.addEventListener('click', () => viewAllDocsModal(article));
     viewAllDocsLink.addEventListener('keydown', (e) => {
@@ -298,21 +298,11 @@ export default async function decorate(block) {
       ...data.applications.map(createDropdownOption),
     );
     const $application = div(
-      { class: 'application select-dropdown', tabindex: '0'  },
+      { class: 'application select-dropdown', tabindex: '0' },
       initialTab,
       selected,
       options,
     );
-
-    // Add keyboard event handling for accessibility
-    $application.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        e.stopPropagation();
-        options.classList.toggle('hidden');
-        dropdownOptions1.classList.add('hidden');
-      }
-    });
 
     // Add focus/blur event listeners for visual indication
     $application.addEventListener('focus', () => {
@@ -338,7 +328,15 @@ export default async function decorate(block) {
       selected1,
       dropdownOptions1,
     );
-
+    // Add keyboard event handling for accessibility
+    $application.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        options.classList.toggle('hidden');
+        dropdownOptions1.classList.add('hidden');
+      }
+    });
     // Add keyboard event handling for accessibility
     $subApplication.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' && !$subApplication.classList.contains('disabled')) {
@@ -415,7 +413,6 @@ export default async function decorate(block) {
 
     selected.addEventListener('click', (e) => {
       e.stopPropagation();
-      const wasHidden = options.classList.contains('hidden');
       options.classList.toggle('hidden');
       dropdownOptions1.classList.add('hidden');
     });

--- a/blocks/ingredient-finder/ingredient-finder.js
+++ b/blocks/ingredient-finder/ingredient-finder.js
@@ -28,7 +28,7 @@ async function createIngredientPanel(ingredientResults) {
   const $filtersList = div();
 
   const $articleCard = (article) => {
-    const addSampleBtn = a({ title: translate('add-sample'), class: 'button add-sample-button' }, translate('add-sample'));
+    const addSampleBtn = a({ title: translate('add-sample'), class: 'button add-sample-button', tabindex: '0' }, translate('add-sample'));
     addSampleBtn.addEventListener('click', () => addIngredientToCart(article.productName, window.location.href));
 
     const description = div({ class: 'description' });
@@ -37,7 +37,7 @@ async function createIngredientPanel(ingredientResults) {
     tempDiv.querySelectorAll('a').forEach(link => link.setAttribute('tabindex', '-1'));
     description.innerHTML = tempDiv.innerHTML;
     
-    const viewAllDocsLink = a({ class: 'view-all' }, translate('view-all-documents'));
+    const viewAllDocsLink = a({ class: 'view-all', tabindex: '0' }, translate('view-all-documents'));
     viewAllDocsLink.addEventListener('click', () => viewAllDocsModal(article));
     const relatedIngredientBlock = div(
       { class: 'related-ingredient' },

--- a/blocks/ingredient-finder/ingredient-finder.js
+++ b/blocks/ingredient-finder/ingredient-finder.js
@@ -107,11 +107,36 @@ function createDropdownOption(item) {
     ? encodeURIComponent(item.key).replace(/%20/g, '+')
     : item.key || '';
   const processedLabel = encodeURIComponent(item.label).replace(/%20/g, '+');
-  return div({
+  const optionDiv = div({
     class: 'dropdown-option',
     'data-key': processedKey,
     'data-encoded-label': processedLabel,
+    tabindex: '0',
   }, item.label);
+
+  // Add keyboard event handling
+  optionDiv.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.stopPropagation();
+      // Trigger the selection logic
+      optionDiv.click();
+    }
+  });
+
+  // Add focus/blur visual indicators
+  optionDiv.addEventListener('focus', () => {
+    optionDiv.style.backgroundColor = '#f0f0f0';
+    optionDiv.style.outline = '2px solid #01090e';
+    optionDiv.style.outlineOffset = '-2px';
+  });
+  optionDiv.addEventListener('blur', () => {
+    optionDiv.style.backgroundColor = '';
+    optionDiv.style.outline = '';
+    optionDiv.style.outlineOffset = '';
+  });
+
+  return optionDiv;
 }
 
 function attachIngredientResults(block, ingredientResults, totalItemsCount, searchValue) {
@@ -272,6 +297,32 @@ export default async function decorate(block) {
       { class: 'dropdown-options hidden' },
       ...data.applications.map(createDropdownOption),
     );
+
+    // Add keyboard navigation for dropdown options
+    options.addEventListener('keydown', (e) => {
+      if (options.classList.contains('hidden')) return;
+
+      const currentOptions = Array.from(options.querySelectorAll('.dropdown-option'));
+      const currentIndex = currentOptions.findIndex(opt => opt === document.activeElement);
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          const nextIndex = Math.min(currentIndex + 1, currentOptions.length - 1);
+          currentOptions[nextIndex].focus();
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          const prevIndex = Math.max(currentIndex - 1, 0);
+          currentOptions[prevIndex].focus();
+          break;
+        case 'Escape':
+          e.preventDefault();
+          options.classList.add('hidden');
+          $application.focus();
+          break;
+      }
+    });
     const $application = div(
       { class: 'application select-dropdown', tabindex: '0'  },
       initialTab,
@@ -284,8 +335,14 @@ export default async function decorate(block) {
       if (e.key === 'Enter') {
         e.preventDefault();
         e.stopPropagation();
+        const wasHidden = options.classList.contains('hidden');
         options.classList.toggle('hidden');
         dropdownOptions1.classList.add('hidden');
+        if (wasHidden && !options.classList.contains('hidden')) {
+          // Focus first option when opening
+          const firstOption = options.querySelector('.dropdown-option');
+          if (firstOption) firstOption.focus();
+        }
       }
     });
 
@@ -307,6 +364,32 @@ export default async function decorate(block) {
     });
     const selected1 = div({ class: 'selected disabled' }, subApplicationText);
     const dropdownOptions1 = div({ class: 'dropdown-options hidden' });
+
+    // Add keyboard navigation for sub-application dropdown options
+    dropdownOptions1.addEventListener('keydown', (e) => {
+      if (dropdownOptions1.classList.contains('hidden')) return;
+
+      const currentOptions = Array.from(dropdownOptions1.querySelectorAll('.dropdown-option'));
+      const currentIndex = currentOptions.findIndex(opt => opt === document.activeElement);
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          const nextIndex = Math.min(currentIndex + 1, currentOptions.length - 1);
+          currentOptions[nextIndex].focus();
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          const prevIndex = Math.max(currentIndex - 1, 0);
+          currentOptions[prevIndex].focus();
+          break;
+        case 'Escape':
+          e.preventDefault();
+          dropdownOptions1.classList.add('hidden');
+          $subApplication.focus();
+          break;
+      }
+    });
     const $subApplication = div(
       { class: 'sub-application select-dropdown disabled', tabindex: '0' },
       initialTab1,
@@ -319,7 +402,13 @@ export default async function decorate(block) {
       if (e.key === 'Enter' && !$subApplication.classList.contains('disabled')) {
         e.preventDefault();
         e.stopPropagation();
+        const wasHidden = dropdownOptions1.classList.contains('hidden');
         dropdownOptions1.classList.toggle('hidden');
+        if (wasHidden && !dropdownOptions1.classList.contains('hidden')) {
+          // Focus first option when opening
+          const firstOption = dropdownOptions1.querySelector('.dropdown-option');
+          if (firstOption) firstOption.focus();
+        }
       }
     });
 
@@ -390,8 +479,14 @@ export default async function decorate(block) {
 
     selected.addEventListener('click', (e) => {
       e.stopPropagation();
+      const wasHidden = options.classList.contains('hidden');
       options.classList.toggle('hidden');
       dropdownOptions1.classList.add('hidden');
+      if (wasHidden && !options.classList.contains('hidden')) {
+        // Focus first option when opening
+        const firstOption = options.querySelector('.dropdown-option');
+        if (firstOption) firstOption.focus();
+      }
     });
 
     options.addEventListener('click', (e) => {
@@ -431,7 +526,13 @@ export default async function decorate(block) {
         return;
       }
       e.stopPropagation();
+      const wasHidden = dropdownOptions1.classList.contains('hidden');
       dropdownOptions1.classList.toggle('hidden');
+      if (wasHidden && !dropdownOptions1.classList.contains('hidden')) {
+        // Focus first option when opening
+        const firstOption = dropdownOptions1.querySelector('.dropdown-option');
+        if (firstOption) firstOption.focus();
+      }
     });
 
     dropdownOptions1.addEventListener('click', (e) => {

--- a/blocks/ingredient-finder/ingredient-finder.js
+++ b/blocks/ingredient-finder/ingredient-finder.js
@@ -30,6 +30,12 @@ async function createIngredientPanel(ingredientResults) {
   const $articleCard = (article) => {
     const addSampleBtn = a({ title: translate('add-sample'), class: 'button add-sample-button', tabindex: '0' }, translate('add-sample'));
     addSampleBtn.addEventListener('click', () => addIngredientToCart(article.productName, window.location.href));
+    addSampleBtn.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        addIngredientToCart(article.productName, window.location.href);
+      }
+    });
 
     const description = div({ class: 'description' });
     const tempDiv = document.createElement('div');
@@ -39,6 +45,12 @@ async function createIngredientPanel(ingredientResults) {
     
     const viewAllDocsLink = a({ class: 'view-all', tabindex: '0' }, translate('view-all-documents'));
     viewAllDocsLink.addEventListener('click', () => viewAllDocsModal(article));
+    viewAllDocsLink.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        viewAllDocsModal(article);
+      }
+    });
     const relatedIngredientBlock = div(
       { class: 'related-ingredient' },
       div(

--- a/blocks/ingredient-finder/ingredient-finder.js
+++ b/blocks/ingredient-finder/ingredient-finder.js
@@ -273,7 +273,7 @@ export default async function decorate(block) {
       ...data.applications.map(createDropdownOption),
     );
     const $application = div(
-      { class: 'application select-dropdown' },
+      { class: 'application select-dropdown', tabindex: '0'  },
       initialTab,
       selected,
       options,

--- a/blocks/ingredient-finder/ingredient-finder.js
+++ b/blocks/ingredient-finder/ingredient-finder.js
@@ -279,6 +279,26 @@ export default async function decorate(block) {
       options,
     );
 
+    // Add keyboard event handling for accessibility
+    $application.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        options.classList.toggle('hidden');
+        dropdownOptions1.classList.add('hidden');
+      }
+    });
+
+    // Add focus/blur event listeners for visual indication
+    $application.addEventListener('focus', () => {
+      $application.style.outline = '2px solid #01090e';
+      $application.style.outlineOffset = '2px';
+    });
+    $application.addEventListener('blur', () => {
+      $application.style.outline = '';
+      $application.style.outlineOffset = '';
+    });
+
     const initialTab1 = input({
       type: 'hidden',
       name: 'initialTab',
@@ -288,11 +308,37 @@ export default async function decorate(block) {
     const selected1 = div({ class: 'selected disabled' }, subApplicationText);
     const dropdownOptions1 = div({ class: 'dropdown-options hidden' });
     const $subApplication = div(
-      { class: 'sub-application select-dropdown disabled' },
+      { class: 'sub-application select-dropdown disabled', tabindex: '0' },
       initialTab1,
       selected1,
       dropdownOptions1,
     );
+
+    // Add keyboard event handling for accessibility
+    $subApplication.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !$subApplication.classList.contains('disabled')) {
+        e.preventDefault();
+        e.stopPropagation();
+        dropdownOptions1.classList.toggle('hidden');
+      }
+    });
+
+    // Add focus/blur event listeners for visual indication
+    $subApplication.addEventListener('focus', () => {
+      if (!$subApplication.classList.contains('disabled')) {
+        $subApplication.style.outline = '2px solid #01090e';
+        $subApplication.style.outlineOffset = '2px';
+      }
+    });
+    $subApplication.addEventListener('blur', () => {
+      $subApplication.style.outline = '';
+      $subApplication.style.outlineOffset = '';
+    });
+
+    // Initially disable tabindex if disabled
+    if ($subApplication.classList.contains('disabled')) {
+      $subApplication.removeAttribute('tabindex');
+    }
 
     if (applications) {
       selected.textContent = applications;
@@ -371,6 +417,7 @@ export default async function decorate(block) {
           selected1.textContent = subApplicationText;
           selected1.classList.remove('disabled');
           $subApplication.classList.remove('disabled');
+          $subApplication.setAttribute('tabindex', '0');
         }
         queryParams = queryParams.replace(/&subApplicationID=[^&]*&subApplications=[^&]*/, '');
         window.history.pushState({}, '', `${pagePath}?${queryParams}`);

--- a/blocks/ingredient-finder/ingredient-finder.js
+++ b/blocks/ingredient-finder/ingredient-finder.js
@@ -32,8 +32,11 @@ async function createIngredientPanel(ingredientResults) {
     addSampleBtn.addEventListener('click', () => addIngredientToCart(article.productName, window.location.href));
 
     const description = div({ class: 'description' });
-    description.innerHTML = (article.description).replace(/&nbsp;/g, ' ');
-
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = (article.description).replace(/&nbsp;/g, ' ');
+    tempDiv.querySelectorAll('a').forEach(link => link.setAttribute('tabindex', '-1'));
+    description.innerHTML = tempDiv.innerHTML;
+    
     const viewAllDocsLink = a({ class: 'view-all' }, translate('view-all-documents'));
     viewAllDocsLink.addEventListener('click', () => viewAllDocsModal(article));
     const relatedIngredientBlock = div(

--- a/blocks/search/product-api-renderer.js
+++ b/blocks/search/product-api-renderer.js
@@ -75,10 +75,21 @@ function createSelectDropdown({
     const $option = li({
       class: `option ${isActive ? 'active' : ''}`,
       style: isActive ? 'padding-right: 30px;' : '',
+      tabindex: '0',
     },
     label,
     count !== undefined ? small(` (${count})`) : '',
     );
+
+    // Add keyboard event handling for accessibility
+    $option.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        onSelect(value, $option, $dropdown);
+        $dropdown.querySelector('.options').classList.remove('open');
+      }
+    });
 
     $option.addEventListener('click', (event) => {
       event.stopPropagation();
@@ -102,7 +113,12 @@ function createSelectDropdown({
     });
 
     // open this one if it was closed
-    if (!isCurrentlyOpen) thisOptionsList.classList.add('open');
+    if (!isCurrentlyOpen) {
+      thisOptionsList.classList.add('open');
+      // Focus first option when opening
+      const firstOption = thisOptionsList.querySelector('.option');
+      if (firstOption) firstOption.focus();
+    }
   });
 
   // Close all dropdowns when clicking outside

--- a/blocks/search/product-api-renderer.js
+++ b/blocks/search/product-api-renderer.js
@@ -61,7 +61,7 @@ function createSelectDropdown({
   cssClass = [],
 }) {
   const $dropdown = div({ class: ['select-dropdown', cssClass] },
-    div({ class: 'selected' }, `${selectedValue || defaultText}${labelSuffix}`),
+    div({ class: 'selected', tabindex: '0' }, `${selectedValue || defaultText}${labelSuffix}`),
     ul({ class: 'options' }),
   );
 
@@ -100,8 +100,10 @@ function createSelectDropdown({
     $dropdown.querySelector('.options').appendChild($option);
   });
 
+  const $selected = $dropdown.querySelector('.selected');
+
   // Add click handler to toggle dropdown
-  $dropdown.querySelector('.selected').addEventListener('click', (event) => {
+  $selected.addEventListener('click', (event) => {
     event.stopPropagation();
 
     const thisOptionsList = $dropdown.querySelector('.options');
@@ -118,6 +120,26 @@ function createSelectDropdown({
       // Focus first option when opening
       const firstOption = thisOptionsList.querySelector('.option');
       if (firstOption) firstOption.focus();
+    }
+  });
+
+  // Add keyboard handler to open dropdown on Enter
+  $selected.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      event.stopPropagation();
+      const thisOptionsList = $dropdown.querySelector('.options');
+      const isCurrentlyOpen = thisOptionsList.classList.contains('open');
+
+      document.querySelectorAll('.select-dropdown .options.open').forEach((optionsList) => {
+        optionsList.classList.remove('open');
+      });
+
+      if (!isCurrentlyOpen) {
+        thisOptionsList.classList.add('open');
+        const firstOption = thisOptionsList.querySelector('.option');
+        if (firstOption) firstOption.focus();
+      }
     }
   });
 

--- a/blocks/search/product-api-renderer.js
+++ b/blocks/search/product-api-renderer.js
@@ -366,7 +366,7 @@ export default class ProductApiRenderer {
       const header = div({ class: 'facet-group__header' });
       const title = h5({ class: 'facet-group__title', tabindex: '0' });
       title.textContent = facetData.label;
-      const toggleIcon = span({ class: 'icon' , tabindex: '0'});
+      const toggleIcon = span({ class: 'icon', tabindex: '0' });
       toggleIcon.textContent = isOpen ? '－' : '＋';
       title.appendChild(toggleIcon);
       header.appendChild(title);

--- a/blocks/search/product-api-renderer.js
+++ b/blocks/search/product-api-renderer.js
@@ -326,9 +326,9 @@ export default class ProductApiRenderer {
       const facetGroupWrapper = div({ class: `facet-group__wrapper${isActive ? ' is-active' : ''}` });
 
       const header = div({ class: 'facet-group__header' });
-      const title = h5({ class: 'facet-group__title' });
+      const title = h5({ class: 'facet-group__title', tabindex: '0' });
       title.textContent = facetData.label;
-      const toggleIcon = span({ class: 'icon' });
+      const toggleIcon = span({ class: 'icon' , tabindex: '0'});
       toggleIcon.textContent = isOpen ? '－' : '＋';
       title.appendChild(toggleIcon);
       header.appendChild(title);
@@ -354,6 +354,27 @@ export default class ProductApiRenderer {
         checkbox.checked = isSelected;
         checkbox.value = option.label;
         checkbox.dataset.facetGroup = facetKey;
+        checkbox.setAttribute('tabindex', '0');
+
+        // Add focus/blur event listeners for visual indication
+        checkbox.addEventListener('focus', () => {
+          label.style.outline = '2px solid #010b11';
+          label.style.outlineOffset = '2px';
+        });
+        checkbox.addEventListener('blur', () => {
+          label.style.outline = '';
+          label.style.outlineOffset = '';
+        });
+
+        // Add keyboard event listener for Enter key
+        checkbox.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            checkbox.checked = !checkbox.checked;
+            // Trigger the change event to apply the filter
+            checkbox.dispatchEvent(new Event('change'));
+          }
+        });
 
         label.appendChild(checkbox);
         label.appendChild(document.createTextNode(`${option.label} (${option.count})`));
@@ -453,6 +474,17 @@ export default class ProductApiRenderer {
         const isCurrentlyOpen = this.groupState[facetKey];
         content.style.display = isCurrentlyOpen ? 'block' : 'none';
         toggleIcon.textContent = isCurrentlyOpen ? '－' : '＋';
+      });
+
+      // Add keyboard event listener for Enter key
+      toggleIcon.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          this.groupState[facetKey] = !this.groupState[facetKey];
+          const isCurrentlyOpen = this.groupState[facetKey];
+          content.style.display = isCurrentlyOpen ? 'block' : 'none';
+          toggleIcon.textContent = isCurrentlyOpen ? '－' : '＋';
+        }
       });
 
       facetGroupWrapper.appendChild(header);


### PR DESCRIPTION
As per the requirement, the highlight should be applied when navigating using the Tab key, and the same functionality should also work when the Enter key is pressed.
To address this, the following updates were implemented:

Change request number: CHG0086158

Added tabindex="0" to enable focus via keyboard navigation.
Added an Enter key event listener to trigger the same behavior as a mouse click.

Test URLs:
- Before: https://main--ingredion--aemsites.aem.live/na/en-us/ingredients/ingredient-finder
- After: https://tabbing--ingredion--aemsites.aem.page/na/en-us/ingredients/ingredient-finder
