### PR TITLE
pointing the endpoints to new andean sharepoint

### DIFF
--- a/scripts/product-api.js
+++ b/scripts/product-api.js
@@ -35,46 +35,57 @@ export const DEFAULT_PATHS = {
 export const API_PATH_OVERRIDES = {
   POPULATE_INGREDIENT_CATEGORY_SUBCATEGORY: {
     'na-es-mx': '/bin/ingredion-com/headeringredient/header.es-mx.search.json',
+    'sa-es-co': '/bin/ingredion-com/headeringredient/header.es-co.search.json',
     'na-kerr': '/bin/ingredion-com/headeringredient/header.kerr.search.json',
   },
   SEARCH_INGREDIENT_BY_CATEGORY_SUBCATEGORY: {
     'na-es-mx': '/bin/ingredion-com/ingredient-finder.es-mx.search.json',
+    'sa-es-co': '/bin/ingredion-com/ingredient-finder.es-co.search.json',
     'na-kerr': '/bin/ingredion-com/ingredient-finder.kerr.search.json',
   },
   INGREDIENT_SEARCH_TYPEAHEAD: {
     'na-es-mx': '/bin/ingredion-com/typeaheadingredient.es-mx.ingredient-search-typeahead.json',
+    'sa-es-co': '/bin/ingredion-com/typeaheadingredient.es-co.ingredient-search-typeahead.json',
     'na-kerr': '/bin/ingredion-com/typeaheadingredient.kerr.ingredient-search-typeahead.json',
   },
   PRODUCT_DETAILS: {
     'na-es-mx': '/bin/ingredion-com/searchResults.es-mx.ingredients.json',
+    'sa-es-co': '/bin/ingredion-com/searchResults.es-co.ingredients.json',
     'na-kerr': '/bin/ingredion-com/searchResults.kerr.ingredients.json',
   },
   ALL_DOCUMENTS: {
     'na-es-mx': '/bin/ingredion-com/documents.es-mx.view.json',
+    'sa-es-co': '/bin/ingredion-com/documents.es-co.view.json',
     'na-kerr': '/bin/ingredion-com/documents.kerr.view.json',
   },
   DOWNLOAD_DOCUMENTS: {
     'na-es-mx': '/bin/ingredion-com/documents-download.es-mx.download.zip',
+    'sa-es-co': '/bin/ingredion-com/documents-download.es-co.download.zip',
     'na-kerr': '/bin/ingredion-com/documents-download.kerr.download.zip',
   },
   DOWNLOAD_ALL_DOCUMENTS: {
     'na-es-mx': '/bin/ingredion-com/documents-download.es-mx.download.zip',
+    'sa-es-co': '/bin/ingredion-com/documents-download.es-co.download.zip',
     'na-kerr': '/bin/ingredion-com/documents-download.kerr.download.zip',
   },
   DOWNLOAD_ALL_DOCUMENTS_FROM_SEARCH: {
     'na-es-mx': '/bin/ingredion-com/documents-download.es-mx.download.zip',
+    'sa-es-co': '/bin/ingredion-com/documents-download.es-co.download.zip',
     'na-kerr': '/bin/ingredion-com/documents-download.kerr.download.zip',
   },
   SEARCH_INGREDIENTS: {
     'na-es-mx': '/bin/ingredion-com/searchResults.es-mx.ingredients.json',
+    'sa-es-co': '/bin/ingredion-com/searchResults.es-co.ingredients.json',
     'na-kerr': '/bin/ingredion-com/searchResults.kerr.ingredients.json',
   },
   SEARCH_DOCUMENTS: {
     'na-es-mx': '/bin/ingredion-com/tech-documents.es-mx.techDocs.json',
+    'sa-es-co': '/bin/ingredion-com/tech-documents.es-co.techDocs.json',
     'na-kerr': '/bin/ingredion-com/tech-documents.kerr.techDocs.json',
   },
   SEARCH_INGREDIENTS_BY_NAME: {
     'na-es-mx': '/bin/ingredion-com/ingredient-finder.es-mx.search.json',
+    'sa-es-co': '/bin/ingredion-com/ingredient-finder.es-co.search.json',
     'na-kerr': '/bin/ingredion-com/ingredient-finder.kerr.search.json',
   },
 };


### PR DESCRIPTION
this PR is for CHG0087684 


This ticket is raised to point the Andean region to a new Sharepoint  [SA Andean - Home.](https://ingredion.sharepoint.com/sites/Product_quality/SA_Andean)

So that the regional products and documents would now be populated from the new Sharepoint.

Now it is pointing to SA region sharepoint.

Test URLs:
- Before: https://main--ingredion--aemsites.aem.live/?martech=off
- After: https://newsharepoint--ingredion--aemsites.aem.live/sa/es-co/nuestros-ingredientes/busca-el-ingrediente
